### PR TITLE
Add .yarn to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,6 @@ dmypy.json
 .pyre/
 
 node_modules
+.yarn
 jupyter_keepalive/labextension
 tsconfig.tsbuildinfo


### PR DESCRIPTION
Otherwise built dist files include all of the yarn cache