### PR TITLE
User ServerApp logger

### DIFF
--- a/jupyter_keepalive/__init__.py
+++ b/jupyter_keepalive/__init__.py
@@ -25,4 +25,6 @@ def _load_jupyter_server_extension(serverapp):
     web_app = serverapp.web_app
     host_pattern = ".*$"
     route_pattern = url_path_join(web_app.settings["base_url"], r"/ext-keepalive")
-    web_app.add_handlers(host_pattern, [(route_pattern, KeepAliveHandler)])
+    web_app.add_handlers(host_pattern, [
+        (route_pattern, KeepAliveHandler, {'logger': serverapp.log})
+        ])

--- a/jupyter_keepalive/__init__.py
+++ b/jupyter_keepalive/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0.dev"
+__version__ = "0.4.1"
 
 
 from jupyter_server.utils import url_path_join

--- a/jupyter_keepalive/__init__.py
+++ b/jupyter_keepalive/__init__.py
@@ -25,6 +25,6 @@ def _load_jupyter_server_extension(serverapp):
     web_app = serverapp.web_app
     host_pattern = ".*$"
     route_pattern = url_path_join(web_app.settings["base_url"], r"/ext-keepalive")
-    web_app.add_handlers(host_pattern, [
-        (route_pattern, KeepAliveHandler, {'logger': serverapp.log})
-        ])
+    web_app.add_handlers(
+        host_pattern, [(route_pattern, KeepAliveHandler, {"logger": serverapp.log})]
+    )

--- a/jupyter_keepalive/handlers.py
+++ b/jupyter_keepalive/handlers.py
@@ -22,7 +22,9 @@ class Spinner:
         Keep the Jupyter server active for `seconds` seconds.
         """
         self.stop()
-        self.logger.info(f"Keeping Jupyter server active for {timedelta(seconds=seconds)}")
+        self.logger.info(
+            f"Keeping Jupyter server active for {timedelta(seconds=seconds)}"
+        )
         start = time.monotonic()
         self.deadline = start + seconds
         self._task = asyncio.create_task(self._spin(seconds))
@@ -62,8 +64,7 @@ class KeepAliveHandler(APIHandler):
     def initialize(self, logger=None):
         if "keepalive_spinner" not in self.settings:
             self.settings["keepalive_spinner"] = Spinner(
-                self.settings["last_activity_times"],
-                logger=logger
+                self.settings["last_activity_times"], logger=logger
             )
         self.spinner = self.settings["keepalive_spinner"]
 

--- a/jupyter_keepalive/handlers.py
+++ b/jupyter_keepalive/handlers.py
@@ -5,12 +5,12 @@ from datetime import datetime, timedelta, timezone
 
 from jupyter_server.base.handlers import APIHandler
 from tornado import web
-from tornado.log import gen_log
 
 
 class Spinner:
-    def __init__(self, last_activity_times, spin_interval=60):
+    def __init__(self, last_activity_times, logger, spin_interval=60):
         self.last_activity_times = last_activity_times
+        self.logger = logger
         self.spinning = False
         self.spin_interval = spin_interval
         self._task = None
@@ -22,7 +22,7 @@ class Spinner:
         Keep the Jupyter server active for `seconds` seconds.
         """
         self.stop()
-        gen_log.info(f"Keeping Jupyter server active for {timedelta(seconds=seconds)}")
+        self.logger.info(f"Keeping Jupyter server active for {timedelta(seconds=seconds)}")
         start = time.monotonic()
         self.deadline = start + seconds
         self._task = asyncio.create_task(self._spin(seconds))
@@ -30,15 +30,15 @@ class Spinner:
     async def _spin(self, seconds):
         deadline = self.deadline or 0
         while time.monotonic() < deadline:
-            gen_log.debug("Setting keepalive activity")
+            self.logger.debug("Setting keepalive activity")
             self.last_activity_times["jupyter-keepalive"] = datetime.now(timezone.utc)
             await asyncio.sleep(self.spin_interval)
-        gen_log.info(f"Keepalive finished after {timedelta(seconds=seconds)}")
+        self.logger.info(f"Keepalive finished after {timedelta(seconds=seconds)}")
 
     def stop(self):
         """Stop keeping alive"""
         if self._task is not None and not self._task.done():
-            gen_log.info("Stopping keepalive spinner")
+            self.logger.info("Stopping keepalive spinner")
             self._task.cancel()
         self.deadline = None
         self._task = None
@@ -59,10 +59,11 @@ DAY_SECONDS = 24 * 60 * 60
 
 
 class KeepAliveHandler(APIHandler):
-    def initialize(self):
+    def initialize(self, logger=None):
         if "keepalive_spinner" not in self.settings:
             self.settings["keepalive_spinner"] = Spinner(
-                self.settings["last_activity_times"]
+                self.settings["last_activity_times"],
+                logger=logger
             )
         self.spinner = self.settings["keepalive_spinner"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minrk/jupyter-keepalive",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A minimal JupyterLab extension with backend and frontend parts.",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ exclude_lines = [
 github_url = "https://github.com/minrk/jupyter-keepalive"
 
 [tool.tbump.version]
-current = "0.4.0.dev"
+current = "0.4.1"
 regex = '''
     (?P<major>\d+)
     \.


### PR DESCRIPTION
Currently logging is done through `tornado.log`, and if enabled, it brings with it lots of unnecessary logging.
This PR switch to using the ServerApp logger, so the messages are clean and separate from the tornado logs.